### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Moodle Plugin CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/moodle-auth_suap/security/code-scanning/1](https://github.com/cte-zl-ifrn/moodle-auth_suap/security/code-scanning/1)

In general, the fix is to explicitly specify `permissions:` for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. For a CI job that checks out code, installs dependencies, runs tests, and uploads artifacts, read-only permissions on repository contents are sufficient; no write scopes or additional permissions appear to be needed.

The best fix here, without changing functionality, is to add a `permissions:` block at the top level of the workflow (so it applies to all jobs) specifying `contents: read`. This goes after the `on:` definition and before `jobs:`. No steps in this workflow need to write to the repository or interact with PRs/issues, so additional permissions such as `pull-requests: write` are not necessary. No imports or other code changes are required, just the YAML addition.

Concretely, in `.github/workflows/ci.yml`, between lines 3 (`on: [push, pull_request]`) and 5 (`jobs:`), insert:

```yml
permissions:
  contents: read
```

This will satisfy CodeQL’s requirement and enforce least privilege for `GITHUB_TOKEN` while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
